### PR TITLE
Configure GHA caching for test target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           targets: test
           set: |
-            test.cache-from=type=gha
-            test.cache-to=type=gha,mode=max
+            test.cache-from=type=gha,scope=${{ matrix.tag }}
+            test.cache-to=type=gha,mode=max,scope=${{ matrix.tag }}
 
       - name: Push image
         uses: docker/bake-action@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,9 @@ jobs:
         uses: docker/bake-action@master
         with:
           targets: test
+          set: |
+            test.cache-from=type=gha
+            test.cache-to=type=gha,mode=max
 
       - name: Push image
         uses: docker/bake-action@master


### PR DESCRIPTION
This is to speed up builds; it'll prime the cache so that the later push step will be using local cache