### PR TITLE
Remove GHA caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,6 @@ jobs:
         uses: docker/bake-action@master
         with:
           targets: test
-          set: |
-            test.cache-from=type=gha,scope=${{ matrix.tag }}
-            test.cache-to=type=gha,mode=max,scope=${{ matrix.tag }}
 
       - name: Push image
         uses: docker/bake-action@master


### PR DESCRIPTION
It's a shame, but when the GHA cache rate-limits that comes across as a build failure

see https://github.com/moby/buildkit/issues/2836